### PR TITLE
[#19] Fix normalization selection

### DIFF
--- a/opengcc/CMakeLists.txt
+++ b/opengcc/CMakeLists.txt
@@ -29,5 +29,11 @@ target_link_libraries(OpenGCC INTERFACE
     pico_stdlib
 )
 
+target_compile_definitions(OpenGCC INTERFACE
+    NONE=0
+    LINEAR=1
+    POLYNOMIAL=2
+)
+
 pico_generate_pio_header(OpenGCC ${CMAKE_CURRENT_SOURCE_DIR}/pio/joybus.pio)
 pico_generate_pio_header(OpenGCC ${CMAKE_CURRENT_SOURCE_DIR}/pio/single_pin_joybus.pio)

--- a/opengcc/calibration.cpp
+++ b/opengcc/calibration.cpp
@@ -84,12 +84,17 @@ stick_calibration_measurement stick_calibration::get_measurement() {
 stick_coefficients stick_calibration::generate_coefficients() {
   stick_coefficients ret;
 
+#if NORMALIZATION_ALGORITHM == NONE
+  ret.x_coefficients = std::array<double, NUM_COEFFICIENTS>{0.0, 1.0};
+  ret.y_coefficients = std::array<double, NUM_COEFFICIENTS>{0.0, 1.0};
+#else
   ret.x_coefficients = fit_curve<NUM_COEFFICIENTS, NUM_CALIBRATION_STEPS>(
       expected_measurement.x_coordinates, actual_measurement.x_coordinates,
       actual_measurement.skipped_measurements);
   ret.y_coefficients = fit_curve<NUM_COEFFICIENTS, NUM_CALIBRATION_STEPS>(
       expected_measurement.y_coordinates, actual_measurement.y_coordinates,
       actual_measurement.skipped_measurements);
+#endif
 
   return ret;
 }


### PR DESCRIPTION
Fixes #19 
`#define`s were meaningless because there was no value set for `NONE`, `LINEAR`, and `POLYNOMIAL`. Also, `NONE` was a lie regardless.